### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
     description="The FASTEST way to consume threat intel",
     long_description="The FASTEST way to consume threat intel",
     url="https://github.com/csirtgadgets/fuzzy-chainsaw",
-    license='MPL2',
     classifiers=[
+               "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
                "Topic :: System :: Networking",
                "Environment :: Other Environment",
                "Intended Audience :: Developers",


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.